### PR TITLE
Change error color so that it's the same as the primary color

### DIFF
--- a/android/app/src/main/java/hu/sarmin/yt2ig/ui/theme/Theme.kt
+++ b/android/app/src/main/java/hu/sarmin/yt2ig/ui/theme/Theme.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.unit.dp
 
 private val DarkColorScheme = darkColorScheme(
     primary = Color(0xFFFF6F61),
-    error = Color(0xFFD04A5C),
+    error = Color(0xFFFF6F61),
     onPrimary = Color(0xFF1D1D1D),
     outline = Color(0xFFE45F55),
     outlineVariant = Color(0xFFB43F51),
@@ -28,7 +28,7 @@ private val DarkColorScheme = darkColorScheme(
 
 private val LightColorScheme = lightColorScheme(
     primary = Color(0xFFFF6F61),
-    error = Color(0xFFD04A5C),
+    error = Color(0xFFFF6F61),
     onPrimary = Color(0xFFFFFFFF),
     secondary = Color(0xFFFFC947),
     onSecondary = Color(0xFF1E1E1E),


### PR DESCRIPTION
We had the issue the error "rose" color was very close to our primary "coral" color. As per the idea of Julcsi Hanák, this changes the error color so that it's the same as the primary